### PR TITLE
Update MainWindowPresenter.cs

### DIFF
--- a/DalamudPlugin/ProximityVoiceChat/UI/Presenter/MainWindowPresenter.cs
+++ b/DalamudPlugin/ProximityVoiceChat/UI/Presenter/MainWindowPresenter.cs
@@ -81,7 +81,9 @@ public class MainWindowPresenter(
                         this.logger.Error("Player name is null, cannot autofill private room name.");
                         return;
                     }
-                    this.view.RoomName.Value = playerName;
+                    var parts = playerName.Split(' ');
+                    var initials = $"{parts[0][0]}. {parts[1][0].";
+                    this.view.RoomName.Value = initials;
                 }
                 this.voiceRoomManager.JoinPrivateVoiceRoom(this.view.RoomName.Value, this.view.RoomPassword.Value);
             }


### PR DESCRIPTION
This should abbreviate the name of whomever is speaking to their initials, and will prevent doxxing and potential report abuse. In the situation where someone cannot tell who is speaking, there is already directional audio for that, plus I feel it would be rare to have that many people with the same initials. This could also get preserved into a toggleable setting in the plugin's config.